### PR TITLE
Add Azure infrastructure for Loki log storage

### DIFF
--- a/loki.tf
+++ b/loki.tf
@@ -1,0 +1,27 @@
+# Managed identity for Loki to access Azure Blob Storage via workload identity
+resource "azurerm_user_assigned_identity" "loki-identity" {
+  name                = "loki"
+  resource_group_name = azurerm_resource_group.equalvote.name
+  location            = azurerm_resource_group.equalvote.location
+}
+
+# Federated credential binding the Loki Kubernetes service account to the Azure managed identity
+resource "azurerm_federated_identity_credential" "loki-federated-credential" {
+  name      = "loki-federated-credential"
+  parent_id = azurerm_user_assigned_identity.loki-identity.id
+  issuer    = azurerm_kubernetes_cluster.equalvote.oidc_issuer_url
+  subject   = "system:serviceaccount:loki:loki"
+  audience  = ["api://AzureADTokenExchange"]
+}
+
+# Grant Loki read/write access to the storage account for log storage
+resource "azurerm_role_assignment" "loki-storage-contributor" {
+  scope                = azurerm_storage_account.storage.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.loki-identity.principal_id
+}
+
+output "loki_client_id" {
+  description = "Client ID for the Loki managed identity. Set this in argocd/applications/loki/values.yaml under serviceAccount.annotations.azure.workload.identity/client-id"
+  value       = azurerm_user_assigned_identity.loki-identity.client_id
+}

--- a/storage.tf
+++ b/storage.tf
@@ -11,3 +11,22 @@ resource "azurerm_storage_container" "candidate-photos" {
   storage_account_id    = azurerm_storage_account.storage.id
   container_access_type = "container"
 }
+
+# Loki log storage containers (private, not publicly accessible)
+resource "azurerm_storage_container" "loki-chunks" {
+  name                  = "loki-chunks"
+  storage_account_id    = azurerm_storage_account.storage.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "loki-ruler" {
+  name                  = "loki-ruler"
+  storage_account_id    = azurerm_storage_account.storage.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "loki-admin" {
+  name                  = "loki-admin"
+  storage_account_id    = azurerm_storage_account.storage.id
+  container_access_type = "private"
+}


### PR DESCRIPTION
## Summary

- Add three private blob containers (`loki-chunks`, `loki-ruler`, `loki-admin`) to the existing `bettervoting` storage account for Loki log storage
- Create a managed identity (`loki`) with a federated credential binding the Kubernetes service account `loki:loki` to Azure, enabling workload identity authentication
- Grant `Storage Blob Data Contributor` role on the storage account to the Loki identity
- Output `loki_client_id` for use in the ArgoCD Helm values

## Post-Apply

After `tofu apply`, copy the `loki_client_id` output into `argocd/applications/loki/values.yaml` at `serviceAccount.annotations.azure.workload.identity/client-id` (replacing `PLACEHOLDER`).

See companion PR: Equal-Vote/argocd (enable-loki-fix-alertmanager branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Established Azure workload identity with federated credentials for Kubernetes service account authentication
  * Provisioned three private cloud storage containers for system operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->