### PR TITLE
add members file for documenting membership

### DIFF
--- a/members.tf
+++ b/members.tf
@@ -1,0 +1,16 @@
+# Membership of the DevOps and Developers AAD groups (defined in main.tf).
+# Members are looked up by UPN; resource labels document each person.
+
+# === DevOps ===
+
+data "azuread_user" "jackson_loper" {
+  user_principal_name = "jackson@starvoting.onmicrosoft.com"
+}
+
+resource "azuread_group_member" "jackson_loper_devops" {
+  group_object_id  = azuread_group.devops.object_id
+  member_object_id = data.azuread_user.jackson_loper.object_id
+}
+
+# === Developers ===
+# (none yet)


### PR DESCRIPTION
To make explicit who has which admin-y powers.  Right now I have All The Powers, which I think is right?  But I'd like to document it and make sure it is clear 😂 .  Presumably we'd add Evans and Arend to this new file.  And Jon as a developer member (or devops if he wants?).  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Terraform setup to grant Azure AD group access by adding a specified user to the existing development group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->